### PR TITLE
Add zoom in shortcut (Ctrl + =)

### DIFF
--- a/src/Apps/NetPad.Apps.App/App/src/core/@application/main-menu/main-menu-service.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/core/@application/main-menu/main-menu-service.ts
@@ -246,8 +246,7 @@ export class MainMenuService implements IMainMenuService {
                     {
                         text: "Zoom In",
                         icon: "zoom-in-icon",
-                        helpText: "Ctrl + =",
-                        click: async () => this.windowService.zoomIn(),
+                        shortcut: this.shortcutManager.getShortcut(ShortcutIds.zoomIn),
                     },
                     {
                         text: "Zoom Out",

--- a/src/Apps/NetPad.Apps.App/App/src/core/@application/shortcuts/builtin-shortcuts.ts
+++ b/src/Apps/NetPad.Apps.App/App/src/core/@application/shortcuts/builtin-shortcuts.ts
@@ -1,5 +1,5 @@
 import {KeyCode} from "@common";
-import {CreateScriptDto, IScriptService, ISettingsService} from "@application";
+import {CreateScriptDto, IScriptService, ISettingsService, IWindowService} from "@application";
 import {Shortcut} from "./shortcut";
 import {ITextEditorService} from "../editor/itext-editor-service";
 
@@ -18,6 +18,7 @@ export enum ShortcutIds {
     openExplorer = "shortcut.explorer.open",
     openNamespaces = "shortcut.namespaces.open",
     reloadWindow = "shortcut.window.reload",
+    zoomIn = "shortcut.window.zoomIn",
 }
 
 export const BuiltinShortcuts = [
@@ -169,5 +170,13 @@ export const BuiltinShortcuts = [
         .hasAction(() => window.location.reload())
         .captureDefaultKeyCombo()
         .configurable()
+        .enabled(),
+
+    new Shortcut(ShortcutIds.zoomIn, "Zoom In")
+        .withCtrlKey()
+        .withKey(KeyCode.Equal)
+        .hasAction((ctx) => ctx.container.get(IWindowService).zoomIn())
+        .captureDefaultKeyCombo()
+        .configurable(false)
         .enabled(),
 ];


### PR DESCRIPTION
@SimonNyvall your PR was perfect, just one change, the key binding for "zoom in" before this change was correct `Ctrl + +` (ie. `Ctrl + Shift + =`). I'm perfectly fine with changing it to `Ctrl + =`, it is more intuitive and similar to how VS Code works. But in order to do that we have to register a keyboard shortcut for `Ctrl + =` to zoom in (more on that below). This PR adds that shortcut.

Thank you for fixing the menu zoom controls, it was definitely annoying haha

**Why do we need a shortcut?**

Before this change, the keyboard shortcuts for zoom were the Electron defaults

- Zoom in is `Ctrl + +` which in reality is `Ctrl + Shift + =` (the `Shift` is needed so the key entered is `+` not `=`)
- Zoom out is `Ctrl + -`
- Reset zoom is `Ctrl + 0`

Since those were the defaults, and those defaults also worked when NetPad is opened in a web browser, I kept them as is. Now when we want zoom in to be `Ctrl + +` that works just fine in a web browser, but Electron doesn't know anything about this shortcut, and so the shortcut doesn't work. So I added a new keyboard shortcut for zoom in in the `builtin-shortcut.ts` file.

An additional note: I added the new shortcut as not configurable (`.configurable(false)`). The only reason I did that is because if its configurable then it shows up in `Settings > Keyboard Shortcuts`. While that's fine, it feels awkward if the user can configure the zoom in but not the zoom out and reset zoom. So we either add all 3 shortcuts as custom shortcuts and make all 3 configurable or we remove this one from being configurable.